### PR TITLE
RF Direction Getters

### DIFF
--- a/dipy/direction/__init__.py
+++ b/dipy/direction/__init__.py
@@ -1,4 +1,6 @@
 
+from .bootstrap_direction_getter import BootDirectionGetter
+from .closest_peak_direction_getter import ClosestPeakDirectionGetter
 from .probabilistic_direction_getter import ProbabilisticDirectionGetter
 from .probabilistic_direction_getter import DeterministicMaximumDirectionGetter
 from .peaks import *

--- a/dipy/direction/bootstrap_direction_getter.py
+++ b/dipy/direction/bootstrap_direction_getter.py
@@ -6,7 +6,8 @@ from dipy.core.geometry import cart2sphere
 from dipy.tracking.local.interpolation import trilinear_interpolate4d
 
 from dipy.data import default_sphere
-from dipy.direction.closest_peak import closest_peak, BaseDirectionGetter
+from dipy.direction.closest_peak_direction_getter import (closest_peak,
+                                                          BaseDirectionGetter)
 
 
 DEFAULT_SH = 4

--- a/dipy/direction/bootstrap_direction_getter.py
+++ b/dipy/direction/bootstrap_direction_getter.py
@@ -43,7 +43,7 @@ class BootOdfGen(object):
         self.H = H
         self.R = R
 
-    def get_pmf(self, point):
+    def get_pmf_boot(self, point):
         """Produces an ODF from a SH bootstrap sample"""
         single_vox_data = trilinear_interpolate4d(self.data, point)
 
@@ -55,7 +55,7 @@ class BootOdfGen(object):
         pmf = fit.odf(self.sphere)
         return pmf
 
-    def pmf_no_boot(self, point):
+    def get_pmf(self, point):
         data = trilinear_interpolate4d(self.data, point)
         fit = self.model.fit(data)
         return fit.odf(self.sphere)
@@ -102,24 +102,6 @@ class BootDirectionGetter(BaseDirectionGetter):
         boot_gen = BootOdfGen(data, model, sphere, sh_order=sh_order)
         return cls(boot_gen, max_angle, sphere, max_attempts, **kwargs)
 
-    def initial_direction(self, point):
-        """Returns best directions at seed location to start tracking.
-
-        Parameters
-        ----------
-        point : ndarray, shape (3,)
-            The point in an image at which to lookup tracking directions.
-
-        Returns
-        -------
-        directions : ndarray, shape (N, 3)
-            Possible tracking directions from point. ``N`` may be 0, all
-            directions should be unique.
-
-        """
-        odf = self.pmf_gen.pmf_no_boot(point)
-        return self._get_peak_directions(odf)
-
     def get_direction(self, point, direction):
         """Attempt direction getting on a few bootstrap samples.
         """
@@ -127,7 +109,7 @@ class BootDirectionGetter(BaseDirectionGetter):
         no_valid_direction = True
         while count < self.max_attempts:
             count += 1
-            pmf = self.pmf_gen.get_pmf(point)
+            pmf = self.pmf_gen.get_pmf_boot(point)
             pmf.clip(min=self.pmf_threshold, out=pmf)
             peaks = self._get_peak_directions(pmf)
             if len(peaks) > 0:

--- a/dipy/direction/closest_peak.py
+++ b/dipy/direction/closest_peak.py
@@ -80,7 +80,7 @@ class BaseDirectionGetter(DirectionGetter):
         self._pf_kwargs = kwargs
         self.pmf_gen = pmf_gen
         if pmf_threshold < 0:
-            raise ValueError("pmf threshould must be >= 0.")
+            raise ValueError("pmf threshold must be >= 0.")
         self.pmf_threshold = pmf_threshold
         self.cos_similarity = np.cos(np.deg2rad(max_angle))
 
@@ -114,10 +114,7 @@ class BaseDirectionGetter(DirectionGetter):
 
 
 class PmfGenDirectionGetter(BaseDirectionGetter):
-    """A direction getter that returns the closest odf peak to previous tracking
-    direction.
-
-    """
+    """A base class for direction getter using a pmf"""
     @classmethod
     def from_pmf(klass, pmf, max_angle, sphere=default_sphere,
                  pmf_threshold=0.1, **kwargs):

--- a/dipy/direction/closest_peak_direction_getter.py
+++ b/dipy/direction/closest_peak_direction_getter.py
@@ -197,7 +197,7 @@ class PmfGenDirectionGetter(BaseDirectionGetter):
         pmf_gen = SHCoeffPmfGen(shcoeff, sphere, basis_type)
         return klass(pmf_gen, max_angle, sphere, pmf_threshold, **kwargs)
 
-class ClosestDirectionGetter(PmfGenDirectionGetter):
+class ClosestPeakDirectionGetter(PmfGenDirectionGetter):
     """A direction getter that returns the closest odf peak to previous tracking
     direction.
     """

--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -2,7 +2,7 @@
 Implementation of a probabilistic direction getter based on sampling from
 discrete distribution (pmf) at each step of the tracking."""
 import numpy as np
-from dipy.direction.closest_peak import PmfGenDirectionGetter
+from dipy.direction.closest_peak_direction_getter import PmfGenDirectionGetter
 
 
 def _asarray(cython_memview):

--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -52,7 +52,7 @@ class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
         dipy.direction.peaks.peak_directions
 
         """
-        PmfDirectionGetter.__init__(self, pmf_gen, max_angle, sphere,
+        PmfGenDirectionGetter.__init__(self, pmf_gen, max_angle, sphere,
                                     pmf_threshold, **kwargs)
         # The vertices need to be in a contiguous array
         self.vertices = self.sphere.vertices.copy()

--- a/dipy/direction/probabilistic_direction_getter.py
+++ b/dipy/direction/probabilistic_direction_getter.py
@@ -2,7 +2,7 @@
 Implementation of a probabilistic direction getter based on sampling from
 discrete distribution (pmf) at each step of the tracking."""
 import numpy as np
-from dipy.direction.closest_peak import ClosestPeakDirectionGetter
+from dipy.direction.closest_peak import PmfGenDirectionGetter
 
 
 def _asarray(cython_memview):
@@ -12,7 +12,7 @@ def _asarray(cython_memview):
     return np.fromiter(cython_memview, float)
 
 
-class ProbabilisticDirectionGetter(ClosestPeakDirectionGetter):
+class ProbabilisticDirectionGetter(PmfGenDirectionGetter):
     """Randomly samples direction of a sphere based on probability mass
     function (pmf).
 
@@ -52,8 +52,8 @@ class ProbabilisticDirectionGetter(ClosestPeakDirectionGetter):
         dipy.direction.peaks.peak_directions
 
         """
-        ClosestPeakDirectionGetter.__init__(self, pmf_gen, max_angle, sphere,
-                                            pmf_threshold, **kwargs)
+        PmfDirectionGetter.__init__(self, pmf_gen, max_angle, sphere,
+                                    pmf_threshold, **kwargs)
         # The vertices need to be in a contiguous array
         self.vertices = self.sphere.vertices.copy()
         self._set_adjacency_matrix(sphere, self.cos_similarity)

--- a/dipy/direction/tests/test_bootstrap_direction_getter.py
+++ b/dipy/direction/tests/test_bootstrap_direction_getter.py
@@ -115,13 +115,13 @@ def test_bdg_get_direction():
     class Fakepmf(object):
         count = 0
 
-        def get_pmf(self, point):
+        def get_pmf_boot(self, point):
             pmf = np.zeros(len(sphere.vertices))
             pmf[two_neighbors[0]] = 1
             self.count += 1
             return pmf
 
-        def pmf_no_boot(self, point):
+        def get_pmf(self, point):
             pass
 
     myfakepmf = Fakepmf()
@@ -179,7 +179,7 @@ def test_bdg_bog_pmfnoboot():
     tensor_model = dti.TensorModel(gtab)
 
     mybog = bdg.BootOdfGen(toy_data, model=tensor_model, sphere=hsph_updated)
-    odf_fit = mybog.pmf_no_boot(np.array([1., 1., 1.]))
+    odf_fit = mybog.get_pmf(np.array([1., 1., 1.]))
 
     myfit = tensor_model.fit(toy_voxel).odf(hsph_updated)
 
@@ -220,8 +220,8 @@ def test_bdg_bog_pmfboot():
     mybog = bdg.BootOdfGen(toy_data, model=csd_model, sphere=hsph_updated,
                            sh_order=6)
     # Two boot samples should be the same if there are no residuales
-    myodf1 = mybog.get_pmf(np.array([1.5, 1.5, 1.5]))
-    myodf2 = mybog.get_pmf(np.array([1.5, 1.5, 1.5]))
+    myodf1 = mybog.get_pmf_boot(np.array([1.5, 1.5, 1.5]))
+    myodf2 = mybog.get_pmf_boot(np.array([1.5, 1.5, 1.5]))
 
     npt.assert_array_almost_equal(myodf1, myodf2)
 
@@ -229,8 +229,8 @@ def test_bdg_bog_pmfboot():
     # should be different
     mybog2 = bdg.BootOdfGen(toy_data, model=csd_model, sphere=hsph_updated,
                             sh_order=4)
-    myodf1 = mybog2.get_pmf(np.array([1.5, 1.5, 1.5]))
-    myodf2 = mybog2.get_pmf(np.array([1.5, 1.5, 1.5]))
+    myodf1 = mybog2.get_pmf_boot(np.array([1.5, 1.5, 1.5]))
+    myodf2 = mybog2.get_pmf_boot(np.array([1.5, 1.5, 1.5]))
 
     npt.assert_(np.any(myodf1 != myodf2))
 


### PR DESCRIPTION
This PR follow the discussion in PR https://github.com/nipy/dipy/pull/1184.

Main changes:
- I renamed `get_pmf(.)` to  `get_pmf_boot(.)` and `get_pmf_no_boot(.)` to `get_pmf(.)`. This allowed to use the same `initial_direction(.)` function.  This also forced me to modify the `get_direction(.)` function.
-I added an extra class `PmfGenDirectionGetter` extending `BaseDirectionGetter` with the 2 class constructors. `ClosestPeakDirectionGetter` and `ProbabilisticDirectionGetter` now inherite from `PmfGenDirectionGetter`.
- With this RF most `DirectionGetter` only redefine the `get_direction(.)` function.

Those changes are mostly cosmetic. Let me know what you think.

Thanks @kesshijordan 
